### PR TITLE
Add DocuBench (document extraction benchmark)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Welcome contributions!
 |    EATEN     | EATEN: Entity-aware Attention for Single Shot Visual Text Extraction                                            |                                                [[link]](https://github.com/beacandler/EATEN)                                                 |
 | Train Ticket | PICK: Processing Key Information Extraction from Documents using Improved Graph Learning-Convolutional Networks |    [[link]](https://github.com/wenwenyu/PICK-pytorch)[[download]](https://drive.google.com/file/d/1o8JktPD7bS74tfjz-8dVcZq_uFS6YEGh/view)    |
 |     POIE     | Visual Information Extraction in the Wild: Practical Dataset and End-to-end Solution                            | [[link]](https://github.com/jfkuang/CFAM)[[download]](https://drive.google.com/file/d/1eEMNiVeLlD-b08XW_GfAGfPmmII-GDYs/view?usp=share_link) |
+|  DocuBench   | DocuBench: A Public Benchmark for Schema-Guided Structured Extraction from Hard Real-World Documents           |                                             [[link]](https://github.com/DocuPipe/DocuBench)                                                 |
 
 ## Survey
 


### PR DESCRIPTION
This adds DocuBench to the Datasets section.

DocuBench is an open benchmark for schema-guided structured extraction: 50 hard real-world documents across 10 file types and 11 languages (including Hebrew, Arabic, Japanese, and Chinese), each paired with a JSON Schema and a hand-verified JSON label. The repo includes a standalone scorer (macro-average field accuracy with order-independent array matching), committed raw outputs from six baseline systems, and an interactive per-document results explorer.

Disclosure: I'm a cofounder of DocuPipe, which built and maintains the benchmark. Every system including ours is scored by the same public scorer against the same labels, and all raw outputs are committed, so the results table is reproducible by running the scorer.

https://github.com/DocuPipe/DocuBench
